### PR TITLE
Add missing semicolons

### DIFF
--- a/tpch/tpch-queries.sql
+++ b/tpch/tpch-queries.sql
@@ -166,15 +166,15 @@ ORDER BY
 
 SELECT name
 FROM tpch.tiny.nation
-WHERE regionkey IN (SELECT regionkey FROM tpch.tiny.region)
+WHERE regionkey IN (SELECT regionkey FROM tpch.tiny.region);
 
 SELECT name
 FROM nation
-WHERE regionkey = ANY (SELECT regionkey FROM region)
+WHERE regionkey = ANY (SELECT regionkey FROM region);
 
 SELECT name
 FROM nation
-WHERE regionkey IN (SELECT regionkey FROM region)
+WHERE regionkey IN (SELECT regionkey FROM region);
 
 SELECT name FROM nation;
 


### PR DESCRIPTION
I've been using the SQL script **tpch/tpch_queries.sql** in the two Start Quickly pages for the some upcoming public Presto docs, running the script from the command line with **presto -f**. But this shows the script ending with errors in red text.

I loaded the script into DbVisualizer and ran it against SEP running locally in Docker. This quickly identified where in the script the errors were coming from. Three semicolons after three of the SELECT statements allowed the script to run without errors.

I would love to get this fix in the primary repo for the book's samples, so that customers can follow the steps in the new docs without wondering about the errors. 

Thanks!